### PR TITLE
Release retained memory by the subscriptionMap

### DIFF
--- a/src/redis-pubsub.ts
+++ b/src/redis-pubsub.ts
@@ -80,6 +80,7 @@ export class RedisPubSub implements PubSubEngine {
     }
 
     this.subsRefsMap[triggerName] = newRefs;
+    delete this.subscriptionMap[subId];
   }
 
   private onMessage(channel: string, message: string) {

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -69,7 +69,11 @@ describe('RedisPubSub', function () {
   });
 
   it('cleans up correctly the memory when unsubscribing', function (done) {
-    pubSub.subscribe('Posts', () => null).then(subId => {
+    Promise.all([
+      pubSub.subscribe('Posts', () => null),
+      pubSub.subscribe('Posts', () => null),
+    ])
+    .then(([subId, secondSubId]) => {
       try {
         // This assertion is done against a private member, if you change the internals, you may want to change that
         expect((pubSub as any).subscriptionMap[subId]).not.to.be.an('undefined');
@@ -77,6 +81,7 @@ describe('RedisPubSub', function () {
         // This assertion is done against a private member, if you change the internals, you may want to change that
         expect((pubSub as any).subscriptionMap[subId]).to.be.an('undefined');
         expect(() => pubSub.unsubscribe(subId)).to.throw(`There is no subscription of id "${subId}"`);
+        pubSub.unsubscribe(secondSubId);
         done();
 
       } catch (e) {

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -53,15 +53,30 @@ describe('RedisPubSub', function () {
   });
 
   it('can unsubscribe from specific redis channel', function (done) {
-
     pubSub.subscribe('Posts', () => null).then(subId => {
+      pubSub.unsubscribe(subId);
+
       try {
-        expect((pubSub as any).subscriptionMap[subId]).not.to.be.an('undefined');
-        pubSub.unsubscribe(subId);
         expect(unsubscribeSpy.callCount).to.equals(1);
         const call = unsubscribeSpy.lastCall;
         expect(call.args).to.have.members(['Posts']);
+        done();
+
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('cleans up correctly the memory when unsubscribing', function (done) {
+    pubSub.subscribe('Posts', () => null).then(subId => {
+      try {
+        // This assertion is done against a private member, if you change the internals, you may want to change that
+        expect((pubSub as any).subscriptionMap[subId]).not.to.be.an('undefined');
+        pubSub.unsubscribe(subId);
+        // This assertion is done against a private member, if you change the internals, you may want to change that
         expect((pubSub as any).subscriptionMap[subId]).to.be.an('undefined');
+        expect(() => pubSub.unsubscribe(subId)).to.throw(`There is no subscription of id "${subId}"`);
         done();
 
       } catch (e) {

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -55,12 +55,13 @@ describe('RedisPubSub', function () {
   it('can unsubscribe from specific redis channel', function (done) {
 
     pubSub.subscribe('Posts', () => null).then(subId => {
-      pubSub.unsubscribe(subId);
-
       try {
+        expect((pubSub as any).subscriptionMap[subId]).not.to.be.an('undefined');
+        pubSub.unsubscribe(subId);
         expect(unsubscribeSpy.callCount).to.equals(1);
         const call = unsubscribeSpy.lastCall;
         expect(call.args).to.have.members(['Posts']);
+        expect((pubSub as any).subscriptionMap[subId]).to.be.an('undefined');
         done();
 
       } catch (e) {


### PR DESCRIPTION
This is done when unsubscribing

Should fix #7 