### PR TITLE
Compile before publishing to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/davidyaha/graphql-redis-subscriptions",
   "scripts": {
     "compile": "tsc",
+    "prepublish": "npm run compile",
     "typings": "typings install && tsdm rewire",
     "pretest": "npm run compile",
     "test": "npm run testonly -- && npm run integration --",


### PR DESCRIPTION
Solves the annoying issue of forgetting to compile before pushing to registry.