### PR TITLE
Implemented Generic AsyncIterator

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "graphql-subscriptions": "^0.4.2",
+    "iterall": "^1.1.1",
     "redis": "^2.6.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "pretest": "npm run compile",
     "test": "npm run testonly -- && npm run integration --",
     "posttest": "npm run lint",
-    "lint": "tslint ./src/**/*.ts",
+    "lint": "tslint --type-check --project ./tsconfig.json ./src/**/*.ts",
     "watch": "tsc -w",
     "testonly": "mocha --reporter spec --full-trace ./dist/test/tests.js ",
     "integration": "npm run compile && mocha --reporter spec --full-trace ./dist/test/integration-tests.js ",
@@ -34,12 +34,10 @@
     "prepublish": "npm run test"
   },
   "dependencies": {
-    "async": "^2.0.1",
-    "graphql-subscriptions": "^0.3.1",
+    "graphql-subscriptions": "^0.4.2",
     "redis": "^2.6.3"
   },
   "devDependencies": {
-    "@types/async": "^2.0.35",
     "@types/chai": "^3.4.34",
     "@types/chai-as-promised": "0.0.30",
     "@types/graphql": "^0.9.0",
@@ -49,13 +47,13 @@
     "@types/simple-mock": "0.0.27",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
-    "graphql": "^0.9.6",
+    "graphql": "^0.10.1",
     "istanbul": "1.0.0-alpha.2",
     "mocha": "^3.0.0",
     "remap-istanbul": "^0.9.5",
     "simple-mock": "^0.7.0",
     "tslint": "^5.2.0",
-    "typescript": "^2.1.4"
+    "typescript": "^2.3.4"
   },
   "typings": "dist/index.d.ts",
   "typescript": {

--- a/src/pubsub-async-iterator.ts
+++ b/src/pubsub-async-iterator.ts
@@ -1,0 +1,111 @@
+import { $$asyncIterator } from 'iterall';
+import {PubSubEngine} from 'graphql-subscriptions/dist/pubsub-engine';
+
+/**
+ * A class for digesting PubSubEngine events via the new AsyncIterator interface.
+ * This implementation is a generic version of the one located at
+ * https://github.com/apollographql/graphql-subscriptions/blob/master/src/event-emitter-to-async-iterator.ts
+ * @class
+ *
+ * @constructor
+ *
+ * @property pullQueue @type {Function[]}
+ * A queue of resolve functions waiting for an incoming event which has not yet arrived.
+ * This queue expands as next() calls are made without PubSubEngine events occurring in between.
+ *
+ * @property pushQueue @type {any[]}
+ * A queue of PubSubEngine events waiting for next() calls to be made.
+ * This queue expands as PubSubEngine events arrice without next() calls occurring in between.
+ *
+ * @property eventsArray @type {string[]}
+ * An array of PubSubEngine event names which this PubSubAsyncIterator should watch.
+ *
+ * @property allSubscribed @type {Promise<number[]>}
+ * A promise of a list of all subscription ids to the passed PubSubEngine.
+ *
+ * @property listening @type {boolean}
+ * Whether or not the PubSubAsynIterator is in listening mode (responding to incoming PubSubEngine events and next() calls).
+ * Listening begins as true and turns to false once the return method is called.
+ *
+ * @property pubsub @type {PubSubEngine}
+ * The PubSubEngine whose events will be observed.
+ */
+export class PubSubAsyncIterator<T> implements AsyncIterator<T> {
+
+  constructor(pubsub: PubSubEngine, eventNames: string | string[]) {
+    this.pubsub = pubsub;
+    this.pullQueue = [];
+    this.pushQueue = [];
+    this.listening = true;
+    this.eventsArray = typeof eventNames === 'string' ? [eventNames] : eventNames;
+    this.allSubscribed = this.subscribeAll();
+  }
+
+  public async next() {
+    await this.allSubscribed;
+    return this.listening ? this.pullValue() : this.return();
+  }
+
+  public async return() {
+    this.emptyQueue(await this.allSubscribed);
+    return { value: undefined, done: true };
+  }
+
+  public async throw(error) {
+    this.emptyQueue(await this.allSubscribed);
+    return Promise.reject(error);
+  }
+
+  public [$$asyncIterator]() {
+    return this;
+  }
+
+  private pullQueue: Function[];
+  private pushQueue: any[];
+  private eventsArray: string[];
+  private allSubscribed: Promise<number[]>;
+  private listening: boolean;
+  private pubsub: PubSubEngine;
+
+  private async pushValue(event) {
+    await this.allSubscribed;
+    if (this.pullQueue.length !== 0) {
+      this.pullQueue.shift()({ value: event, done: false });
+    } else {
+      this.pushQueue.push(event);
+    }
+  }
+
+  private pullValue() {
+    return new Promise((resolve => {
+      if (this.pushQueue.length !== 0) {
+        resolve({ value: this.pushQueue.shift(), done: false });
+      } else {
+        this.pullQueue.push(resolve);
+      }
+    }).bind(this));
+  }
+
+  private emptyQueue(subscriptionIds: number[]) {
+    if (this.listening) {
+      this.listening = false;
+      this.unsubscribeAll(subscriptionIds);
+      this.pullQueue.forEach(resolve => resolve({ value: undefined, done: true }));
+      this.pullQueue.length = 0;
+      this.pushQueue.length = 0;
+    }
+  }
+
+  private subscribeAll() {
+    return Promise.all(this.eventsArray.map(
+      eventName => this.pubsub.subscribe(eventName, this.pushValue.bind(this), {}),
+    ));
+  }
+
+  private unsubscribeAll(subscriptionIds: number[]) {
+    for (const subscriptionId of subscriptionIds) {
+      this.pubsub.unsubscribe(subscriptionId);
+    }
+  }
+
+}

--- a/src/redis-pubsub.ts
+++ b/src/redis-pubsub.ts
@@ -1,6 +1,6 @@
-import {PubSubEngine} from 'graphql-subscriptions/dist/pubsub';
+import {PubSubEngine} from 'graphql-subscriptions/dist/pubsub-engine';
 import {createClient, RedisClient, ClientOpts as RedisOptions} from 'redis';
-import {each} from 'async';
+import {PubSubAsyncIterator} from './pubsub-async-iterator';
 
 export interface PubSubRedisOptions {
   connection?: RedisOptions;
@@ -87,6 +87,10 @@ export class RedisPubSub implements PubSubEngine {
     delete this.subscriptionMap[subId];
   }
 
+  public asyncIterator<T>(triggers: string | string[]): AsyncIterator<T> {
+    return new PubSubAsyncIterator<T>(this, triggers);
+  }
+
   private onMessage(channel: string, message: string) {
     const subscribers = this.subsRefsMap[channel];
 
@@ -100,12 +104,10 @@ export class RedisPubSub implements PubSubEngine {
       parsedMessage = message;
     }
 
-    each(subscribers, (subId, cb) => {
-      // TODO Support pattern based subscriptions
-      const [triggerName, listener] = this.subscriptionMap[subId];
+    for (const subId of subscribers) {
+      const listener = this.subscriptionMap[subId][1];
       listener(parsedMessage);
-      cb();
-    });
+    }
   }
 
   private triggerTransform: TriggerTransform;

--- a/src/test/integration-tests.ts
+++ b/src/test/integration-tests.ts
@@ -2,6 +2,7 @@ import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 
 import {
+  parse,
   GraphQLSchema,
   GraphQLObjectType,
   GraphQLString,
@@ -16,61 +17,62 @@ chai.use(chaiAsPromised);
 const expect = chai.expect;
 const assert = chai.assert;
 
-const schema = new GraphQLSchema({
-  query: new GraphQLObjectType({
-    name: 'Query',
-    fields: {
-      testString: {
-        type: GraphQLString,
-        resolve: function (_, args) {
-          return 'works';
-        },
-      },
-    },
-  }),
-  subscription: new GraphQLObjectType({
-    name: 'Subscription',
-    fields: {
-      testSubscription: {
-        type: GraphQLString,
-        resolve: function (root) {
-          return root;
-        },
-      },
-      testFilter: {
-        type: GraphQLString,
-        resolve: function (root, { filterBoolean }) {
-          return filterBoolean ? 'goodFilter' : 'badFilter';
-        },
-        args: {
-          filterBoolean: { type: GraphQLBoolean },
-        },
-      },
-      testFilterMulti: {
-        type: GraphQLString,
-        resolve: function (root, { filterBoolean }) {
-          return filterBoolean ? 'goodFilter' : 'badFilter';
-        },
-        args: {
-          filterBoolean: { type: GraphQLBoolean },
-          a: { type: GraphQLString },
-          b: { type: GraphQLInt },
-        },
-      },
-      testChannelOptions: {
-        type: GraphQLString,
-        resolve: function (root) {
-          return root;
-        },
-        args: {
-          repoName: {type: GraphQLString},
-        },
-      },
-    },
-  }),
-});
-
 describe('SubscriptionManager', function() {
+
+  const schema = new GraphQLSchema({
+    query: new GraphQLObjectType({
+      name: 'Query',
+      fields: {
+        testString: {
+          type: GraphQLString,
+          resolve: function (_, args) {
+            return 'works';
+          },
+        },
+      },
+    }),
+    subscription: new GraphQLObjectType({
+      name: 'Subscription',
+      fields: {
+        testSubscription: {
+          type: GraphQLString,
+          resolve: function (root) {
+            return root;
+          },
+        },
+        testFilter: {
+          type: GraphQLString,
+          resolve: function (root, { filterBoolean }) {
+            return filterBoolean ? 'goodFilter' : 'badFilter';
+          },
+          args: {
+            filterBoolean: { type: GraphQLBoolean },
+          },
+        },
+        testFilterMulti: {
+          type: GraphQLString,
+          resolve: function (root, { filterBoolean }) {
+            return filterBoolean ? 'goodFilter' : 'badFilter';
+          },
+          args: {
+            filterBoolean: { type: GraphQLBoolean },
+            a: { type: GraphQLString },
+            b: { type: GraphQLInt },
+          },
+        },
+        testChannelOptions: {
+          type: GraphQLString,
+          resolve: function (root) {
+            return root;
+          },
+          args: {
+            repoName: {type: GraphQLString},
+          },
+        },
+      },
+    }),
+  });
+
   const subManager = new SubscriptionManager({
     schema,
     setupFunctions: {
@@ -222,11 +224,13 @@ describe('SubscriptionManager', function() {
       testSubscription  @skip(if: $uga)
     }`;
     const callback = function(err, payload){
-      console.log("inside callback. payload =", payload);
       try {
         // tslint:disable-next-line:no-unused-expression
-        expect(payload).to.be.undefined;
-        expect(err.message).to.equals('Variable "$uga" of required type "Boolean!" was not provided.');
+        expect(payload).to.exist;
+        // tslint:disable-next-line:no-unused-expression
+        expect(payload.errors).to.exist;
+        expect(payload.errors.length).to.equal(1);
+        expect(payload.errors[0].message).to.equal('Variable "$uga" of required type "Boolean!" was not provided.');
       } catch (e) {
         done(e);
         return;
@@ -283,5 +287,86 @@ describe('SubscriptionManager', function() {
       setTimeout(() => pubsub.unsubscribe(subId), 4);
     });
 
+  });
+});
+
+
+// From https://github.com/apollographql/graphql-subscriptions/blob/master/src/test/asyncIteratorSubscription.ts
+import { isAsyncIterable } from 'iterall';
+import { mock } from 'simple-mock';
+import { withFilter } from '../with-filter';
+import { subscribe } from 'graphql/subscription';
+const FIRST_EVENT = 'FIRST_EVENT';
+
+function buildSchema(iterator) {
+  return new GraphQLSchema({
+    query: new GraphQLObjectType({
+      name: 'Query',
+      fields: {
+        testString: {
+          type: GraphQLString,
+          resolve: function(_, args) {
+            return 'works';
+          },
+        },
+      },
+    }),
+    subscription: new GraphQLObjectType({
+      name: 'Subscription',
+      fields: {
+        testSubscription: {
+          type: GraphQLString,
+          subscribe: withFilter(
+            () => iterator,
+            () => true,
+          ),
+          resolve: root => {
+            return 'FIRST_EVENT';
+          },
+        },
+      },
+    }),
+  });
+}
+
+describe('PubSubAsyncIterator', function() {
+
+  const query = parse(`
+    subscription S1 {
+      testSubscription
+    }
+  `);
+
+  const pubsub = new RedisPubSub();
+  const origIterator = pubsub.asyncIterator(FIRST_EVENT);
+  const returnSpy = mock(origIterator, 'return');
+  const schema = buildSchema(origIterator);
+  const results = subscribe(schema, query);
+
+  it('should allow subscriptions', () => {
+    const payload1 = results.next();
+
+    // tslint:disable-next-line:no-unused-expression
+    expect(isAsyncIterable(results)).to.be.true;
+
+    const r = payload1.then(res => {
+      expect(res.value.data.testSubscription).to.equal('FIRST_EVENT');
+    });
+
+    pubsub.publish(FIRST_EVENT, {});
+
+    return r;
+  });
+
+  it('should clear event handlers', () => {
+    const end = results.return();
+
+    const r = end.then(res => {
+      expect(returnSpy.callCount).to.be.gte(1);
+    });
+
+    pubsub.publish(FIRST_EVENT, {});
+
+    return r;
   });
 });

--- a/src/test/integration-tests.ts
+++ b/src/test/integration-tests.ts
@@ -222,6 +222,7 @@ describe('SubscriptionManager', function() {
       testSubscription  @skip(if: $uga)
     }`;
     const callback = function(err, payload){
+      console.log("inside callback. payload =", payload);
       try {
         // tslint:disable-next-line:no-unused-expression
         expect(payload).to.be.undefined;

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -1,7 +1,7 @@
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import {spy, restore} from 'simple-mock';
-
+import {isAsyncIterable} from 'iterall';
 import * as redis from 'redis';
 import {RedisPubSub} from '../redis-pubsub';
 
@@ -35,13 +35,10 @@ redisPackage['createClient'] = createClient;
 
 // -------------- Mocking Redis Client ------------------
 
-
 describe('RedisPubSub', function () {
 
-  const pubSub = new RedisPubSub();
-
   it('can subscribe to specific redis channel and called when a message is published on it', function (done) {
-
+    const pubSub = new RedisPubSub();
     pubSub.subscribe('Posts', message => {
       try {
         expect(message).to.equals('test');
@@ -58,6 +55,7 @@ describe('RedisPubSub', function () {
   });
 
   it('can unsubscribe from specific redis channel', function (done) {
+    const pubSub = new RedisPubSub();
     pubSub.subscribe('Posts', () => null).then(subId => {
       pubSub.unsubscribe(subId);
 
@@ -74,6 +72,7 @@ describe('RedisPubSub', function () {
   });
 
   it('cleans up correctly the memory when unsubscribing', function (done) {
+    const pubSub = new RedisPubSub();
     Promise.all([
       pubSub.subscribe('Posts', () => null),
       pubSub.subscribe('Posts', () => null),
@@ -96,6 +95,7 @@ describe('RedisPubSub', function () {
   });
 
   it('will not unsubscribe from the redis channel if there is another subscriber on it\'s subscriber list', function (done) {
+    const pubSub = new RedisPubSub();
     const subscriptionPromises = [
       pubSub.subscribe('Posts', () => {
         done('Not supposed to be triggered');
@@ -127,6 +127,7 @@ describe('RedisPubSub', function () {
   });
 
   it('will subscribe to redis channel only once', function (done) {
+    const pubSub = new RedisPubSub();
     const onMessage = () => null;
     const subscriptionPromises = [
       pubSub.subscribe('Posts', onMessage),
@@ -148,6 +149,7 @@ describe('RedisPubSub', function () {
   });
 
   it('can have multiple subscribers and all will be called when a message is published to this channel', function (done) {
+    const pubSub = new RedisPubSub();
     const onMessageSpy = spy(() => null);
     const subscriptionPromises = [
       pubSub.subscribe('Posts', onMessageSpy as Function),
@@ -175,6 +177,7 @@ describe('RedisPubSub', function () {
   });
 
   it('can publish objects as well', function (done) {
+    const pubSub = new RedisPubSub();
     pubSub.subscribe('Posts', message => {
       try {
         expect(message).to.have.property('comment', 'This is amazing');
@@ -193,6 +196,7 @@ describe('RedisPubSub', function () {
   });
 
   it('throws if you try to unsubscribe with an unknown id', function () {
+    const pubSub = new RedisPubSub();
     return expect(() => pubSub.unsubscribe(123))
       .to.throw('There is no subscription of id "123"');
   });
@@ -229,6 +233,83 @@ describe('RedisPubSub', function () {
 
   after('Restore redis client', () => {
     restore();
+  });
+
+});
+
+describe('PubSubAsyncIterator', function() {
+
+  it('should expose valid asyncItrator for a specific event', () => {
+    const pubSub = new RedisPubSub();
+    const eventName = 'test';
+    const iterator = pubSub.asyncIterator(eventName);
+    expect(iterator).to.exist;
+    expect(isAsyncIterable(iterator)).to.be.true;
+  });
+
+  it('should trigger event on asyncIterator when published', done => {
+    const pubSub = new RedisPubSub();
+    const eventName = 'test';
+    const iterator = pubSub.asyncIterator(eventName);
+
+    iterator.next().then(result => {
+      expect(result).to.exist;
+      expect(result.value).to.exist;
+      expect(result.done).to.exist;
+      done();
+    });
+
+    pubSub.publish(eventName, { test: true });
+  });
+
+  it('should not trigger event on asyncIterator when publishing other event', () => {
+    const pubSub = new RedisPubSub();
+    const eventName = 'test2';
+    const iterator = pubSub.asyncIterator('test');
+    const triggerSpy = spy(() => undefined);
+
+    iterator.next().then(triggerSpy);
+    pubSub.publish(eventName, { test: true });
+    expect(triggerSpy.callCount).to.equal(0);
+  });
+
+  it('register to multiple events', done => {
+    const pubSub = new RedisPubSub();
+    const eventName = 'test2';
+    const iterator = pubSub.asyncIterator(['test', 'test2']);
+    const triggerSpy = spy(() => undefined);
+
+    iterator.next().then(() => {
+      triggerSpy();
+      expect(triggerSpy.callCount).to.be.gte(1);
+      done();
+    });
+    pubSub.publish(eventName, { test: true });
+  });
+
+  it('should not trigger event on asyncIterator already returned', done => {
+    const pubSub = new RedisPubSub();
+    const eventName = 'test';
+    const iterator = pubSub.asyncIterator<any>(eventName);
+
+    iterator.next().then(result => {
+      expect(result).to.exist;
+      expect(result.value).to.exist;
+      expect(result.value.test).to.equal('word');
+      expect(result.done).to.be.false;
+    });
+
+    pubSub.publish(eventName, { test: 'word' });
+
+    iterator.next().then(result => {
+      expect(result).to.exist;
+      expect(result.value).not.to.exist;
+      expect(result.done).to.be.true;
+      done();
+    });
+
+    iterator.return();
+    pubSub.publish(eventName, { test: true });
   });
 
 });

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -243,7 +243,9 @@ describe('PubSubAsyncIterator', function() {
     const pubSub = new RedisPubSub();
     const eventName = 'test';
     const iterator = pubSub.asyncIterator(eventName);
+    // tslint:disable-next-line:no-unused-expression
     expect(iterator).to.exist;
+    // tslint:disable-next-line:no-unused-expression
     expect(isAsyncIterable(iterator)).to.be.true;
   });
 
@@ -253,8 +255,11 @@ describe('PubSubAsyncIterator', function() {
     const iterator = pubSub.asyncIterator(eventName);
 
     iterator.next().then(result => {
+      // tslint:disable-next-line:no-unused-expression
       expect(result).to.exist;
+      // tslint:disable-next-line:no-unused-expression
       expect(result.value).to.exist;
+      // tslint:disable-next-line:no-unused-expression
       expect(result.done).to.exist;
       done();
     });
@@ -293,17 +298,23 @@ describe('PubSubAsyncIterator', function() {
     const iterator = pubSub.asyncIterator<any>(eventName);
 
     iterator.next().then(result => {
+      // tslint:disable-next-line:no-unused-expression
       expect(result).to.exist;
+      // tslint:disable-next-line:no-unused-expression
       expect(result.value).to.exist;
       expect(result.value.test).to.equal('word');
+      // tslint:disable-next-line:no-unused-expression
       expect(result.done).to.be.false;
     });
 
     pubSub.publish(eventName, { test: 'word' });
 
     iterator.next().then(result => {
+      // tslint:disable-next-line:no-unused-expression
       expect(result).to.exist;
+      // tslint:disable-next-line:no-unused-expression
       expect(result.value).not.to.exist;
+      // tslint:disable-next-line:no-unused-expression
       expect(result.done).to.be.true;
       done();
     });

--- a/src/with-filter.ts
+++ b/src/with-filter.ts
@@ -1,0 +1,42 @@
+import { $$asyncIterator } from 'iterall';
+
+export type FilterFn = (rootValue?: any, args?: any, context?: any, info?: any) => boolean;
+export type ResolverFn = (rootValue?: any, args?: any, context?: any, info?: any) => AsyncIterator<any>;
+
+export const withFilter = (asyncIteratorFn: () => AsyncIterator<any>, filterFn: FilterFn): Function => {
+  return (rootValue: any, args: any, context: any, info: any): AsyncIterator<any> => {
+    const asyncIterator = asyncIteratorFn();
+
+    const getNextPromise = () => {
+      return asyncIterator
+        .next()
+        .then(payload => Promise.all([
+          payload,
+          Promise.resolve(filterFn(payload.value, args, context, info)).catch(() => false),
+        ]))
+        .then(([payload, filterResult]) => {
+          if (filterResult === true) {
+            return payload;
+          }
+
+          // Skip the current value and wait for the next one
+          return getNextPromise();
+        });
+    };
+
+    return {
+      next() {
+        return getNextPromise();
+      },
+      return() {
+        return asyncIterator.return();
+      },
+      throw(error) {
+        return asyncIterator.throw(error);
+      },
+      [$$asyncIterator]() {
+        return this;
+      },
+    };
+  };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "pretty": true,
     "removeComments": true,
     "declaration": true,
-    "lib": ["es6"]
+    "lib": ["es6","esnext"]
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
I think the best solution would be to submit a PR directly to graphql-subscriptions, changing the PubSubEngine from an interface to an abstract class, so that all classes which inherit the PubSubEngine super abstract class will already have an AsyncIterator implemented.