### PR TITLE
Replace 'redis' library with 'ioredis' for Cluster and Sentinel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,5 +91,5 @@ const pubsub = new RedisPubSub({
 });
 ```
 
-You can learn more on the redis options object [here](https://github.com/NodeRedis/node_redis#options-object-properties).
+You can learn more on the redis options object [here](https://github.com/luin/ioredis/blob/master/API.md#new_Redis_new).
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,28 @@ The subscription string that Redis will receive will be `comments.added.graphql-
 This subscription string is much more specific and means the the filtering required for this type of subscription is not needed anymore.
 This is one step towards lifting the load off of the graphql api server regarding subscriptions.
 
+## Creating the Redis Client
+
+But for any production usage, it is recommended to send a redis client from outside.
+
+```javascript
+import { RedisPubSub } from 'graphql-redis-subscriptions';
+import * as Redis from 'ioredis';
+
+const options = {
+  host: REDIS_DOMAIN_NAME,
+  port: PORT_NUMBER,
+  retry_strategy: options => {
+    // reconnect after
+    return Math.max(options.attempt * 100, 3000);
+  }
+};
+
+const pubsub = new RedisPubSub({...}, new Redis(options), new Redis(options));
+```
+
+You can learn more on ioredis package [here](https://github.com/luin/ioredis).
+
 ## Passing redis options object
 
 The basic usage is great for development and you will be able to connect to a redis server running on your system seamlessly.

--- a/package.json
+++ b/package.json
@@ -35,16 +35,16 @@
   },
   "dependencies": {
     "graphql-subscriptions": "^0.4.2",
-    "iterall": "^1.1.1",
-    "redis": "^2.6.3"
+    "ioredis": "^3.1.2",
+    "iterall": "^1.1.1"
   },
   "devDependencies": {
     "@types/chai": "^4.0.1",
     "@types/chai-as-promised": "0.0.31",
     "@types/graphql": "^0.9.0",
+    "@types/ioredis": "0.0.24",
     "@types/mocha": "^2.2.33",
     "@types/node": "7.0.19",
-    "@types/redis": "^2.6.0",
     "@types/simple-mock": "0.0.27",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "graphql-subscriptions": "^0.4.2",
-    "ioredis": "^3.1.2",
     "iterall": "^1.1.1"
   },
   "devDependencies": {
@@ -49,12 +48,16 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "graphql": "^0.10.1",
+    "ioredis": "^3.1.2",
     "istanbul": "1.0.0-alpha.2",
     "mocha": "^3.0.0",
     "remap-istanbul": "^0.9.5",
     "simple-mock": "^0.8.0",
     "tslint": "^5.2.0",
     "typescript": "^2.3.4"
+  },
+  "optionalDependencies": {
+    "ioredis": "^3.1.2"
   },
   "typings": "dist/index.d.ts",
   "typescript": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "remap-istanbul": "^0.9.5",
     "simple-mock": "^0.8.0",
     "tslint": "^5.2.0",
-    "typescript": "2.3.4"
+    "typescript": "^2.3.4"
   },
   "typings": "dist/index.d.ts",
   "typescript": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "remap-istanbul": "^0.9.5",
     "simple-mock": "^0.8.0",
     "tslint": "^5.2.0",
-    "typescript": "^2.3.4"
+    "typescript": "2.3.4"
   },
   "typings": "dist/index.d.ts",
   "typescript": {

--- a/src/redis-pubsub.ts
+++ b/src/redis-pubsub.ts
@@ -6,22 +6,25 @@ export interface PubSubRedisOptions {
   connection?: RedisOptions;
   triggerTransform?: TriggerTransform;
   connectionListener?: (err: Error) => void;
+  publisher?: RedisClient;
+  subscriber?: RedisClient;
 }
 
 export class RedisPubSub implements PubSubEngine {
 
-  constructor(options: PubSubRedisOptions = {}, publisher?: RedisClient, subscriber?: RedisClient) {
+  constructor(options: PubSubRedisOptions = {}) {
     this.triggerTransform = options.triggerTransform || (trigger => trigger as string);
-    if (subscriber && publisher) {
-      this.redisPublisher = publisher;
-      this.redisSubscriber = subscriber;
+    if (options.subscriber && options.publisher) {
+      this.redisPublisher = options.publisher;
+      this.redisSubscriber = options.subscriber;
     } else {
       try {
         const IORedis = require('ioredis');
         this.redisPublisher = new IORedis(options.connection);
         this.redisSubscriber = new IORedis(options.connection);
       } catch (error) {
-        console.error(`Package 'ioredis' wasn't found. Couldn't create Redis clients.`)
+        console.error(`Nor publisher or subscriber instances were provided and the package 'ioredis' wasn't found. 
+        Couldn't create Redis clients.`)
       }
 
     }

--- a/src/redis-pubsub.ts
+++ b/src/redis-pubsub.ts
@@ -1,5 +1,6 @@
+import * as IORedis from 'ioredis';
+import { RedisOptions, Redis as RedisClient } from 'ioredis';
 import { PubSubEngine } from 'graphql-subscriptions/dist/pubsub-engine';
-import { createClient, RedisClient, ClientOpts as RedisOptions } from 'redis';
 import { PubSubAsyncIterator } from './pubsub-async-iterator';
 
 export interface PubSubRedisOptions {
@@ -13,8 +14,8 @@ export class RedisPubSub implements PubSubEngine {
   constructor(options: PubSubRedisOptions = {}) {
     this.triggerTransform = options.triggerTransform || (trigger => trigger as string);
 
-    this.redisPublisher = createClient(options.connection);
-    this.redisSubscriber = createClient(options.connection);
+    this.redisPublisher = new IORedis(options.connection);
+    this.redisSubscriber = new IORedis(options.connection);
 
     // TODO support for pattern based message
     this.redisSubscriber.on('message', this.onMessage.bind(this));

--- a/src/redis-pubsub.ts
+++ b/src/redis-pubsub.ts
@@ -104,6 +104,14 @@ export class RedisPubSub implements PubSubEngine {
     return new PubSubAsyncIterator<T>(this, triggers);
   }
 
+  public getSubscriber(): RedisClient {
+    return this.redisSubscriber;
+  }
+
+  public getPublisher(): RedisClient {
+    return this.redisPublisher;
+  }
+
   private onMessage(channel: string, message: string) {
     const subscribers = this.subsRefsMap[channel];
 

--- a/src/redis-pubsub.ts
+++ b/src/redis-pubsub.ts
@@ -13,9 +13,8 @@ export class RedisPubSub implements PubSubEngine {
 
   constructor(options: PubSubRedisOptions = {}) {
     this.triggerTransform = options.triggerTransform || (trigger => trigger as string);
-
-    this.redisPublisher = new IORedis(options.connection);
-    this.redisSubscriber = new IORedis(options.connection);
+    this.redisPublisher = (IORedis as any).createClient(options.connection);
+    this.redisSubscriber = (IORedis as any).createClient(options.connection);
 
     // TODO support for pattern based message
     this.redisSubscriber.on('message', this.onMessage.bind(this));

--- a/src/test/integration-tests.ts
+++ b/src/test/integration-tests.ts
@@ -130,6 +130,7 @@ describe('SubscriptionManager', function () {
       subManager.publish('testSubscription', 'good');
       setTimeout(() => {
         subManager.unsubscribe(subId);
+        done();
       }, 2);
     });
   });

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -1,8 +1,8 @@
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
+import * as IORedis from 'ioredis';
 import { spy, restore } from 'simple-mock';
 import { isAsyncIterable } from 'iterall';
-import * as IORedis from 'ioredis';
 import { RedisPubSub } from '../redis-pubsub';
 
 chai.use(chaiAsPromised);

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -3,6 +3,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import { spy, restore } from 'simple-mock';
 import { isAsyncIterable } from 'iterall';
 import { RedisPubSub } from '../redis-pubsub';
+import * as IORedis from 'ioredis';
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -26,7 +27,7 @@ const mockRedisClient = {
 };
 const mockOptions = {
   publisher: (mockRedisClient as any),
-  subscriber: (mockRedisClient as any)
+  subscriber: (mockRedisClient as any),
 };
 
 
@@ -34,6 +35,13 @@ const mockOptions = {
 // -------------- Mocking Redis Client ------------------
 
 describe('RedisPubSub', function () {
+
+  it('should create default ioredis clients if none were provided', function (done) {
+    const pubSub = new RedisPubSub();
+    expect(pubSub.getSubscriber()).to.be.an.instanceOf(IORedis);
+    expect(pubSub.getPublisher()).to.be.an.instanceOf(IORedis);
+    done();
+  });
 
   it('can subscribe to specific redis channel and called when a message is published on it', function (done) {
     const pubSub = new RedisPubSub(mockOptions);
@@ -204,7 +212,7 @@ describe('RedisPubSub', function () {
     const pubSub = new RedisPubSub({
       triggerTransform,
       publisher: (mockRedisClient as any),
-      subscriber: (mockRedisClient as any)
+      subscriber: (mockRedisClient as any),
     });
 
     const validateMessage = message => {

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -2,7 +2,7 @@ import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import { spy, restore } from 'simple-mock';
 import { isAsyncIterable } from 'iterall';
-import * as redis from 'redis';
+import * as IORedis from 'ioredis';
 import { RedisPubSub } from '../redis-pubsub';
 
 chai.use(chaiAsPromised);
@@ -16,7 +16,7 @@ const publishSpy = spy((channel, message) => listener && listener(channel, messa
 const subscribeSpy = spy((channel, cb) => cb && cb(null, channel));
 const unsubscribeSpy = spy((channel, cb) => cb && cb(channel));
 
-const redisPackage = redis as Object;
+const redisPackage = IORedis as Object;
 
 const createClient = function () {
   return {


### PR DESCRIPTION
Luckily, ioredis implements an almost identical API:
https://github.com/luin/ioredis/wiki/Migrating-from-node_redis

Note:
I deleted the ^ from typescript in package.json because it installs version 2.4 and this project isn't compatible with it - so the CI won't pass.