### PR TITLE
fix subsRefsMap mem leak

### DIFF
--- a/src/redis-pubsub.ts
+++ b/src/redis-pubsub.ts
@@ -71,19 +71,14 @@ export class RedisPubSub implements PubSubEngine {
 
     if (!refs) throw new Error(`There is no subscription of id "${subId}"`);
 
-    let newRefs;
     if (refs.length === 1) {
       this.redisSubscriber.unsubscribe(triggerName);
-      newRefs = [];
-
+      delete this.subsRefsMap[triggerName];
     } else {
       const index = refs.indexOf(subId);
-      if (index !== -1) {
-        newRefs = [...refs.slice(0, index), ...refs.slice(index + 1)];
-      }
+      const newRefs = index === -1 ? refs : [...refs.slice(0, index), ...refs.slice(index + 1)];
+      this.subsRefsMap[triggerName] = newRefs;
     }
-
-    this.subsRefsMap[triggerName] = newRefs;
     delete this.subscriptionMap[subId];
   }
 


### PR DESCRIPTION
subsRefsMap can grow unbounded since the keys are never cleaned up. (this affects the rabbitmq version, looks like).

also fixes edge case of invalid index.

might be worthwhile to move to a hashtable like https://github.com/chad3814/node-hashtable or even redis to store the refs.

alternatively, if you wanna stay in JS land, i might suggest `subsRefMap = {[channel]: Set<onMessageHandler>}` and if CPU is more important than memory, building an index like `{[socketId]: Set<onMessageHandler>}` to replace subscriptionMap for fast unsubscribes as you currently have. I wouldn't do this though. My guess is that by the time the subsRefMap gets large enough to warrant a subscriptionsMap index, you won't have the memory for it, so it'd be better to keep to a single object & just iterate over it. Mutating sets is often faster than immutably splicing arrays, too.