### PR TITLE
Add support for psubscribe

### DIFF
--- a/src/redis-pubsub.ts
+++ b/src/redis-pubsub.ts
@@ -47,8 +47,7 @@ export class RedisPubSub implements PubSubEngine {
       }
     }
 
-    // TODO support for pattern based message
-    this.redisSubscriber.on('message', this.onMessage.bind(this));
+    this.redisSubscriber.on('pmessage', this.onMessage.bind(this));
 
     this.subscriptionMap = {};
     this.subsRefsMap = {};
@@ -76,8 +75,7 @@ export class RedisPubSub implements PubSubEngine {
       return Promise.resolve(id);
     } else {
       return new Promise<number>((resolve, reject) => {
-        // TODO Support for pattern subs
-        this.redisSubscriber.subscribe(triggerName, err => {
+        this.redisSubscriber.psubscribe(triggerName, err => {
           if (err) {
             reject(err);
           } else {
@@ -124,8 +122,8 @@ export class RedisPubSub implements PubSubEngine {
     return this.redisPublisher;
   }
 
-  private onMessage(channel: string, message: string) {
-    const subscribers = this.subsRefsMap[channel];
+  private onMessage(pattern: string, channel: string, message: string) {
+    const subscribers = this.subsRefsMap[pattern];
 
     // Don't work for nothing..
     if (!subscribers || !subscribers.length) return;

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -12,15 +12,15 @@ const expect = chai.expect;
 
 let listener;
 
-const publishSpy = spy((channel, message) => listener && listener(channel, message));
+const publishSpy = spy((channel, message) => listener && listener(channel, channel, message));
 const subscribeSpy = spy((channel, cb) => cb && cb(null, channel));
 const unsubscribeSpy = spy((channel, cb) => cb && cb(channel));
 const mockRedisClient = {
   publish: publishSpy,
-  subscribe: subscribeSpy,
+  psubscribe: subscribeSpy,
   unsubscribe: unsubscribeSpy,
   on: (event, cb) => {
-    if (event === 'message') {
+    if (event === 'pmessage') {
       listener = cb;
     }
   },


### PR DESCRIPTION
I have added support for psubscribe to allow for patterned topics.

Only issue I ran into was the integration test `PubSubAsyncIterator should allow subscriptions` would time out - however I noticed there was an issue referencing integration tests already so tested within my app and everything worked as expected.

Closes #91 