### PR TITLE
fix: add asyncIterable method and correct documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Greenkeeper badge](https://badges.greenkeeper.io/davidyaha/graphql-redis-subscriptions.svg)](https://greenkeeper.io/)
 [![Build Status](https://travis-ci.org/davidyaha/graphql-redis-subscriptions.svg?branch=master)](https://travis-ci.org/davidyaha/graphql-redis-subscriptions)
 
-This package implements the PubSubEngine Interface from the [graphql-subscriptions](https://github.com/apollographql/graphql-subscriptions) package and also the new AsyncIterator interface. 
+This package implements the PubSubEngine Interface from the [graphql-subscriptions](https://github.com/apollographql/graphql-subscriptions) package and also the new AsyncIterable interface. 
 It allows you to connect your subscriptions manger to a redis Pub Sub mechanism to support 
 multiple subscription manager instances.
    
-## Using as AsyncIterator
+## Using as AsyncIterable
 
 Define your GraphQL schema with a `Subscription` type:
 
@@ -34,7 +34,7 @@ import { RedisPubSub } from 'graphql-redis-subscriptions';
 const pubsub = new RedisPubSub();
 ```
 
-Now, implement your Subscriptions type resolver, using the `pubsub.asyncIterator` to map the event you need:
+Now, implement your Subscriptions type resolver, using the `pubsub.asyncIterable` to map the event you need:
 
 ```javascript
 const SOMETHING_CHANGED_TOPIC = 'something_changed';
@@ -42,7 +42,7 @@ const SOMETHING_CHANGED_TOPIC = 'something_changed';
 export const resolvers = {
   Subscription: {
     somethingChanged: {
-      subscribe: () => pubsub.asyncIterator(SOMETHING_CHANGED_TOPIC),
+      subscribe: () => pubsub.asyncIterable(SOMETHING_CHANGED_TOPIC),
     },
   },
 }
@@ -50,7 +50,7 @@ export const resolvers = {
 
 > Subscriptions resolvers are not a function, but an object with `subscribe` method, that returns `AsyncIterable`.
 
-Calling the method `asyncIterator` of the `RedisPubSub` instance will send redis a `SUBSCRIBE` message to the topic provided and will return an `AsyncIterator` binded to the RedisPubSub instance and listens to any event published on that topic.
+Calling the method `asyncIterable` of the `RedisPubSub` instance will send redis a `SUBSCRIBE` message to the topic provided and will return an `AsyncIterable` binded to the RedisPubSub instance and listens to any event published on that topic.
 Now, the GraphQL engine knows that `somethingChanged` is a subscription, and every time we will use `pubsub.publish` over this topic, the `RedisPubSub` will `PUBLISH` the event over redis to all other subscribed instances and those in their turn will emit the event to GraphQL using the `next` callback given by the GraphQL engine.
 
 ```js
@@ -63,7 +63,7 @@ pubsub.publish(SOMETHING_CHANGED_TOPIC, { somethingChanged: { id: "123" }});
 export const resolvers = {
   Subscription: {
     somethingChanged: {
-      subscribe: (_, args) => pubsub.asyncIterator(`${SOMETHING_CHANGED_TOPIC}.${args.relevantId}`),
+      subscribe: (_, args) => pubsub.asyncIterable(`${SOMETHING_CHANGED_TOPIC}.${args.relevantId}`),
     },
   },
 }
@@ -78,7 +78,7 @@ export const resolvers = {
   Subscription: {
     somethingChanged: {
       subscribe: withFilter(
-        (_, args) => pubsub.asyncIterator(`${SOMETHING_CHANGED_TOPIC}.${args.relevantId}`),
+        (_, args) => pubsub.asyncIterable(`${SOMETHING_CHANGED_TOPIC}.${args.relevantId}`),
         (payload, variables) => payload.somethingChanged.id === variables.relevantId,
       ),
     },

--- a/src/redis-pubsub.ts
+++ b/src/redis-pubsub.ts
@@ -121,6 +121,8 @@ export class RedisPubSub implements PubSubEngine {
   }
 
   public asyncIterable<T>(triggers: string | string[]): AsyncIterable<T> {
+    // @ts-ignore: unfortunately the TypeScript type for $$asyncIterator doesn't work
+    // in place of Symbol.iterator
     return {
       [$$asyncIterator]: () => new PubSubAsyncIterator<T>(this, triggers),
     };

--- a/src/redis-pubsub.ts
+++ b/src/redis-pubsub.ts
@@ -1,3 +1,4 @@
+import { $$asyncIterator } from 'iterall';
 import { RedisOptions, Redis as RedisClient } from 'ioredis';
 import { PubSubEngine } from 'graphql-subscriptions';
 import { PubSubAsyncIterator } from './pubsub-async-iterator';
@@ -117,6 +118,12 @@ export class RedisPubSub implements PubSubEngine {
 
   public asyncIterator<T>(triggers: string | string[]): AsyncIterator<T> {
     return new PubSubAsyncIterator<T>(this, triggers);
+  }
+
+  public asyncIterable<T>(triggers: string | string[]): AsyncIterable<T> {
+    return {
+      [$$asyncIterator]: () => new PubSubAsyncIterator<T>(this, triggers),
+    };
   }
 
   public getSubscriber(): RedisClient {


### PR DESCRIPTION
(See https://github.com/apollographql/graphql-subscriptions/issues/143 and https://github.com/apollographql/graphql-subscriptions/pull/147)

Unfortunately, with async iteration being so new, a lot of misinformation wound up in the documentation for `graphql-sequelize` **(GraphQL `subscribe` resolvers must return an `AsyncIterable`, not an `AsyncIterator`)** and consequently the design of `PubSubEngine.asyncIterator` unsafely mashes together an `AsyncIterable` and `AsyncIterator`.  

In my upcoming PR to `graphql-subscriptions` the `asyncIterator` method will be deprecated in favor of an `asyncIterable` method.

## What's unsafe about the current design?

**`PubSubEngine.asyncIterator` can cause dangling listeners.**  In normal usage with `subscriptions-transport-ws` I don't believe this is a problem, but if the franken-`AsyncIter(ator/able)` is consumed by 3rd-party async generators, especially if they use `for await` loops, its `return()` method may not get called, and the listeners don't get cleaned up.  For example:

```js
const numLoggedInUsersSubscription = {
  type: graphql.GraphQLInt,
  subscribe: (doc, args, context) => {
    // Note: immediately yielding the current value is going to become more
    // common as people realize that it's possible to miss updates between
    // when the query results come in and the subscription is started.

    const numLoggedInUsers = context.usersHandler.numLoggedInUsers()
    return addInitialValue(
      numLoggedInUsers,
      // <<< Event listeners get registered by this call >>>
      context.pubsub.asyncIterator(NUM_LOGGED_IN_USERS)
    )
  }
}

function addInitialValue(initialValue, iterable) {
  async function * createIterator() {
    yield initialValue
    // <<< But if the subscription stops before this loop, >>>
    // <<< The event listeners will never get removed >>>
    for await (let value of iterable) {
      yield value
    }
  }
  return {
    [Symbol.asyncIterator]: createIterator,
  }
}
```