### PR TITLE
Travis build should target node stable and lts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
+  - "node"
+  - "lts/*"
   - "6"
-  - "8"
 
 cache:
   directories:


### PR DESCRIPTION
According to [nodejs/release](https://github.com/nodejs/release), Node 6 will be transitioned to Maintenance LTS on April 30, 2018 and will reach End of Life on April 2019.

Travis build should target Node stable (9.X) and Active LTS (8.X)
https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions
