### PR TITLE
Update Iterall to latest version 1.1.3 => 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prepublishOnly": "npm run test"
   },
   "dependencies": {
-    "iterall": "^1.1.3"
+    "iterall": "^1.2.2"
   },
   "peerDependencies": {
     "graphql-subscriptions": "^1.0.0"


### PR DESCRIPTION
The older version of Iterall has memory leak issues. 
With large amounts of messages published, you'll run out of memory.

This describes the issue.
https://github.com/apollographql/graphql-subscriptions/issues/97