### PR TITLE
Fix issue #164

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ import * as Redis from 'ioredis';
 const options = {
   host: REDIS_DOMAIN_NAME,
   port: PORT_NUMBER,
-  retry_strategy: options => {
+  retryStrategy: times => {
     // reconnect after
-    return Math.max(options.attempt * 100, 3000);
+    return Math.min(times * 50, 2000);
   }
 };
 


### PR DESCRIPTION
Changes `retry_strategy` to `retryStrategy` since this is the option expected by ioredis.

Changed the default value to be just like their [current documentation on Auto-reconnect](https://github.com/luin/ioredis/blob/98ebeec1acd2067e52169f53e57e989ebbf671ff/README.md#auto-reconnect).
