### PR TITLE
Make it possible to wait until all redis instances finish the quit routine

### DIFF
--- a/src/redis-pubsub.ts
+++ b/src/redis-pubsub.ts
@@ -133,9 +133,11 @@ export class RedisPubSub implements PubSubEngine {
     return this.redisPublisher;
   }
 
-  public close(): void {
-    this.redisPublisher.quit();
-    this.redisSubscriber.quit();
+  public close(): Promise<any> {
+    return Promise.all([
+      this.redisPublisher.quit(),
+      this.redisSubscriber.quit(),
+    ]);
   }
 
   private onMessage(pattern: string, channel: string, message: string) {

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -53,9 +53,13 @@ describe('RedisPubSub', () => {
 
   it('should verify close calls pub and sub quit methods', done => {
     const pubSub = new RedisPubSub(mockOptions);
-    pubSub.close();
-    expect(quitSpy.callCount).to.equal(2);
-    done();
+
+    pubSub.close()
+      .then(() => {
+        expect(quitSpy.callCount).to.equal(2);
+        done();
+      })
+      .catch(done);
   });
 
   it('can subscribe to specific redis channel and called when a message is published on it', done => {


### PR DESCRIPTION
ioredis' quit() is async.. this change allow caller to wait so proper shutdown can be achieved via waiting for close() method