### PR TITLE
fix: asyncIterator typescript return type

### DIFF
--- a/src/redis-pubsub.ts
+++ b/src/redis-pubsub.ts
@@ -1,6 +1,7 @@
 import {Cluster, Ok, Redis, RedisOptions} from 'ioredis';
-import {PubSubEngine} from 'graphql-subscriptions';
+
 import {PubSubAsyncIterator} from './pubsub-async-iterator';
+import {PubSubEngine} from 'graphql-subscriptions';
 
 type RedisClient = Redis | Cluster;
 type OnMessage<T> = (message: T) => void;
@@ -136,8 +137,9 @@ export class RedisPubSub implements PubSubEngine {
     delete this.subscriptionMap[subId];
   }
 
-  public asyncIterator<T>(triggers: string | string[], options?: unknown): AsyncIterator<T> {
-    return new PubSubAsyncIterator<T>(this, triggers, options);
+  // return type can be simplified after https://github.com/leebyron/iterall/issues/49 is resolved
+  public asyncIterator<T>(triggers: string | string[], options?: unknown): PubSubAsyncIterator<T> & AsyncIterator<T> & AsyncIterable<T> {
+    return new PubSubAsyncIterator<T>(this, triggers, options) as unknown as PubSubAsyncIterator<T> & AsyncIterator<T> & AsyncIterable<T>;
   }
 
   public getSubscriber(): RedisClient {

--- a/src/test/integration-tests.ts
+++ b/src/test/integration-tests.ts
@@ -1,13 +1,14 @@
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
-import { mock } from 'simple-mock';
-import { parse, GraphQLSchema, GraphQLObjectType, GraphQLString, GraphQLFieldResolver } from 'graphql';
-import { isAsyncIterable } from 'iterall';
-import { subscribe } from 'graphql/subscription';
 
-import { RedisPubSub } from '../redis-pubsub';
-import { withFilter } from '../with-filter';
+import { GraphQLFieldResolver, GraphQLObjectType, GraphQLSchema, GraphQLString, parse } from 'graphql';
+
 import { Cluster } from 'ioredis';
+import { RedisPubSub } from '../redis-pubsub';
+import { isAsyncIterable } from 'iterall';
+import { mock } from 'simple-mock';
+import { subscribe } from 'graphql/subscription';
+import { withFilter } from '../with-filter';
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;


### PR DESCRIPTION
I updated asyncIterator's type to include Iterable so that it can be used with `for...of`. Unfortunately iterall's $$asyncIterator doesn't play nice with typescript, so I had to add some ts-ignores.