### PR TITLE
types: allow specifiying enums for allowed triggers

### DIFF
--- a/src/redis-pubsub.ts
+++ b/src/redis-pubsub.ts
@@ -16,7 +16,7 @@ export interface PubSubRedisOptions {
   deserializer?: Deserializer;
 }
 
-export class RedisPubSub implements PubSubEngine {
+export class RedisPubSub<Triggers = string> implements PubSubEngine {
 
   constructor(options: PubSubRedisOptions = {}) {
     const {
@@ -78,12 +78,12 @@ export class RedisPubSub implements PubSubEngine {
     this.currentSubscriptionId = 0;
   }
 
-  public async publish<T>(trigger: string, payload: T): Promise<void> {
+  public async publish<T>(trigger: Triggers, payload: T): Promise<void> {
     await this.redisPublisher.publish(trigger, this.serializer ? this.serializer(payload) : JSON.stringify(payload));
   }
 
   public subscribe<T = any>(
-    trigger: string,
+    trigger: Triggers,
     onMessage: OnMessage<T>,
     options: unknown = {},
   ): Promise<number> {
@@ -136,7 +136,7 @@ export class RedisPubSub implements PubSubEngine {
     delete this.subscriptionMap[subId];
   }
 
-  public asyncIterator<T>(triggers: string | string[], options?: unknown): AsyncIterator<T> {
+  public asyncIterator<T>(triggers: Triggers | Triggers[], options?: unknown): AsyncIterator<T> {
     return new PubSubAsyncIterator<T>(this, triggers, options);
   }
 


### PR DESCRIPTION
This makes it possible to do something like:

```ts
export enum SubscriptionsTopics {
  A,
  B,
};

const redis = new IORedis();

export const graphqlPubsub = new RedisPubSub<SubscriptionsTopics>({
  publisher: redis,
  subscriber: redis,
});
```

