### PR TITLE
fix: construct IORedis with strings

### DIFF
--- a/src/redis-pubsub.ts
+++ b/src/redis-pubsub.ts
@@ -6,7 +6,7 @@ type RedisClient = Redis | Cluster;
 type OnMessage<T> = (message: T) => void;
 
 export interface PubSubRedisOptions {
-  connection?: RedisOptions;
+  connection?: RedisOptions | string;
   triggerTransform?: TriggerTransform;
   connectionListener?: (err: Error) => void;
   publisher?: RedisClient;


### PR DESCRIPTION
`new IORedis('redis://localhost:6379/')` is a valid way to construct an IORedis client.

Updated `PubSubRedisOptions.connection` to allow for strings as well.
Tested in a project dependent upon this library.

See https://github.com/luin/ioredis#connect-to-redis