### PR TITLE
feat: prepare for ioredis v5

### DIFF
--- a/src/redis-pubsub.ts
+++ b/src/redis-pubsub.ts
@@ -1,4 +1,4 @@
-import {Cluster, Ok, Redis, RedisOptions} from 'ioredis';
+import {Cluster, Redis, RedisOptions} from 'ioredis';
 import {PubSubEngine} from 'graphql-subscriptions';
 import {PubSubAsyncIterator} from './pubsub-async-iterator';
 
@@ -152,7 +152,7 @@ export class RedisPubSub implements PubSubEngine {
     return this.redisPublisher;
   }
 
-  public close(): Promise<Ok[]> {
+  public close(): Promise<'OK'[]> {
     return Promise.all([
       this.redisPublisher.quit(),
       this.redisSubscriber.quit(),


### PR DESCRIPTION
`ioredis` recently published a new version with built-in types.

Those types are not 100% compatible with the types declared in `@types/ioredis`, but with this PR and luin/ioredis#1552 everything should work again.