### PR TITLE
update ioredis and remove deprecated types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@istanbuljs/nyc-config-typescript": "^1.0.1",
         "@types/chai": "^4.2.12",
         "@types/chai-as-promised": "^7.1.3",
-        "@types/ioredis": "^4.17.3",
         "@types/mocha": "^9.1.1",
         "@types/node": "16.11.7",
         "@types/simple-mock": "^0.8.1",
@@ -26,7 +25,7 @@
         "eslint": "^7.7.0",
         "graphql": "^15.7.2",
         "graphql-subscriptions": "^2.0.0",
-        "ioredis": "^5.1.0",
+        "ioredis": "^5.2.4",
         "mocha": "^10.0.0",
         "nyc": "^15.1.0",
         "simple-mock": "^0.8.0",
@@ -34,7 +33,7 @@
         "typescript": "^4.0.2"
       },
       "optionalDependencies": {
-        "ioredis": "^5.1.0"
+        "ioredis": "^5.2.4"
       },
       "peerDependencies": {
         "graphql-subscriptions": "^1.0.0 || ^2.0.0"
@@ -613,15 +612,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
-    },
-    "node_modules/@types/ioredis": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.1.tgz",
-      "integrity": "sha512-raYHPqRWrfnEoym94BY28mG1+tcZqh3dsp2q7x5IyMAAEvIdu+H0X8diASMpncIm+oHyH9dalOeOnGOL/YnuOA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.5",
@@ -2272,9 +2262,9 @@
       "dev": true
     },
     "node_modules/ioredis": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.1.0.tgz",
-      "integrity": "sha512-HYHnvwxFwefeUBj0hZFejLvd8Q/YNAfnZlZG/hSRxkRhXMs1H8soMEVccHd1WlLrKkynorXBsAtqDGskOdAfVQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.2.4.tgz",
+      "integrity": "sha512-qIpuAEt32lZJQ0XyrloCRdlEdUUNGG9i0UOk6zgzK6igyudNWqEBxfH6OlbnOOoBBvr1WB02mm8fR55CnikRng==",
       "dev": true,
       "dependencies": {
         "@ioredis/commands": "^1.1.1",
@@ -4803,15 +4793,6 @@
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
     },
-    "@types/ioredis": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.1.tgz",
-      "integrity": "sha512-raYHPqRWrfnEoym94BY28mG1+tcZqh3dsp2q7x5IyMAAEvIdu+H0X8diASMpncIm+oHyH9dalOeOnGOL/YnuOA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/json-schema": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
@@ -6003,9 +5984,9 @@
       "dev": true
     },
     "ioredis": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.1.0.tgz",
-      "integrity": "sha512-HYHnvwxFwefeUBj0hZFejLvd8Q/YNAfnZlZG/hSRxkRhXMs1H8soMEVccHd1WlLrKkynorXBsAtqDGskOdAfVQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.2.4.tgz",
+      "integrity": "sha512-qIpuAEt32lZJQ0XyrloCRdlEdUUNGG9i0UOk6zgzK6igyudNWqEBxfH6OlbnOOoBBvr1WB02mm8fR55CnikRng==",
       "dev": true,
       "requires": {
         "@ioredis/commands": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@types/chai": "^4.2.12",
     "@types/chai-as-promised": "^7.1.3",
-    "@types/ioredis": "^4.17.3",
     "@types/mocha": "^9.1.1",
     "@types/node": "16.11.7",
     "@types/simple-mock": "^0.8.1",
@@ -57,7 +56,7 @@
     "eslint": "^7.7.0",
     "graphql": "^15.7.2",
     "graphql-subscriptions": "^2.0.0",
-    "ioredis": "^5.1.0",
+    "ioredis": "^5.2.4",
     "mocha": "^10.0.0",
     "nyc": "^15.1.0",
     "simple-mock": "^0.8.0",
@@ -65,7 +64,7 @@
     "typescript": "^4.0.2"
   },
   "optionalDependencies": {
-    "ioredis": "^5.1.0"
+    "ioredis": "^5.2.4"
   },
   "typings": "dist/index.d.ts",
   "typescript": {


### PR DESCRIPTION
Ioredis was updated to version 5.2.4 which breaks type compatibility with this package.
This PR updates ioredis to the newest version + it removes the dependency to the definitely typed package as ioredis provides its own types now, see:
https://www.npmjs.com/package/@types/ioredis