### PR TITLE
Fix: buffer messages from external resource

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-redis-subscriptions",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "A graphql-subscriptions PubSub Engine using redis",
   "main": "dist/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-redis-subscriptions",
-  "version": "2.6.1",
+  "version": "2.6.0",
   "description": "A graphql-subscriptions PubSub Engine using redis",
   "main": "dist/index.js",
   "repository": {

--- a/src/test/integration-tests.ts
+++ b/src/test/integration-tests.ts
@@ -123,6 +123,29 @@ describe('PubSubAsyncIterator', function() {
       }));
 });
 
+describe('Subscribe to buffer', () => {
+  it('can publish buffers as well' , done => {
+    // when using messageBuffer, with redis instance the channel name is not a string but a buffer
+    const pubSub = new RedisPubSub({ messageEventName: 'messageBuffer'});
+    const payload = 'This is amazing';
+    pubSub.subscribe('Posts', message => {
+      try {
+        expect(message).to.be.instanceOf(Buffer);
+        expect(message.toString('utf-8')).to.be.equal(payload);
+        done();
+      } catch (e) {
+        done(e);
+      }
+    }).then(async subId => {
+      try {
+        await pubSub.publish('Posts', Buffer.from(payload, 'utf-8'));
+        pubSub.unsubscribe(subId);
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+})
 
 describe('PubSubCluster', () => {
     const nodes = [7006, 7001, 7002, 7003, 7004, 7005].map(port => ({ host: '127.0.0.1', port }));


### PR DESCRIPTION
- When setting the to messageEventName: 'messageBuffer', the channel is received as buffer. I have added a check to set it as such.
- The buffer is also serialized as json when so I have checked if it as a buffer and return it as it is.
תודה !