### PR TITLE
Add an optional filterFn to PubSubAsyncIterator to workaround performance issues found in withFilter

### DIFF
--- a/src/redis-pubsub.ts
+++ b/src/redis-pubsub.ts
@@ -1,6 +1,7 @@
 import {Cluster, Redis, RedisOptions} from 'ioredis';
 import {PubSubEngine} from 'graphql-subscriptions';
 import {PubSubAsyncIterator} from './pubsub-async-iterator';
+import { FilterFn } from './with-filter';
 
 type RedisClient = Redis | Cluster;
 type OnMessage<T> = (message: T) => void;
@@ -139,8 +140,8 @@ export class RedisPubSub implements PubSubEngine {
     delete this.subscriptionMap[subId];
   }
 
-  public asyncIterator<T>(triggers: string | string[], options?: unknown): AsyncIterator<T> {
-    return new PubSubAsyncIterator<T>(this, triggers, options);
+  public asyncIterator<T>(triggers: string | string[], options?: unknown, filterFn?: FilterFn): AsyncIterator<T> {
+    return new PubSubAsyncIterator<T>(this, triggers, options, filterFn);
   }
 
   public getSubscriber(): RedisClient {

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -451,6 +451,26 @@ describe('PubSubAsyncIterator', () => {
     pubSub.publish(eventName, { test: true });
   });
 
+  it('should only publish filtered events', done => {
+    const pubSub = new RedisPubSub(mockOptions);
+    const eventName = 'test';
+    const iterator = pubSub.asyncIterator(eventName, undefined, (eventData) => eventData.filtered === false);
+
+    iterator.next().then(result => {
+      // tslint:disable-next-line:no-unused-expression
+      expect(result).to.exist;
+      // tslint:disable-next-line:no-unused-expression
+      expect(result.value).to.exist;
+      // tslint:disable-next-line:no-unused-expression
+      expect(result.done).to.exist;
+      expect(result.value.filtered).to.equal(false);
+      done();
+    });
+
+    pubSub.publish(eventName, { filtered: true });
+    pubSub.publish(eventName, { filtered: false });
+  });
+
   it('should not trigger event on asyncIterator when publishing other event', async () => {
     const pubSub = new RedisPubSub(mockOptions);
     const eventName = 'test2';

--- a/src/with-filter.ts
+++ b/src/with-filter.ts
@@ -1,5 +1,10 @@
 export type FilterFn = (rootValue?: any, args?: any, context?: any, info?: any) => boolean;
 
+/**
+ * Wraps an async-iterator and filters incoming events based on the provided filter function.
+ * Note: Due to promise chaining this function can use a large amount of memory when a high percentage of messages are filtered
+ * If using the PubSubAsyncIterator, use the filterFn property directly
+ */
 export const withFilter = (asyncIteratorFn: () => AsyncIterableIterator<any>, filterFn: FilterFn) => {
   return (rootValue: any, args: any, context: any, info: any): AsyncIterator<any> => {
     const asyncIterator = asyncIteratorFn();


### PR DESCRIPTION
Our production application filters a high number of messages, more than 99% are filtered out. We suffered an issue of unbounded memory growth caused by the behavior of `withFilter`. Our understanding is that `withFilter` will continue chaining promises together until a message is accepted. Because of our aggressive filtering our containers would quickly run out of memory

<img width="1014" alt="Screenshot%202023-05-01%20at%2011 43 15%20AM" src="https://user-images.githubusercontent.com/2341305/236575158-e2a61c7c-1792-4255-8429-8bac5028e87b.png">

We have since improved our sharding behavior so that we are filtering less messages, but we still think there is an improvement that can be made to filtering. 

This PR adds a `filterFn` to `PubSubAsyncIterator` so that messages can be filtered immediately before insertion into the queue. We believe this is a performance win regardless of how many messages are being filtered. Thank you!