### PR TITLE
chore: export type definitions for options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { RedisPubSub } from './redis-pubsub';
+export type { PubSubRedisOptions } from './redis-pubsub'


### PR DESCRIPTION
Exports the type definitions for configuration so we don't need to import like this:
`import type { PubSubRedisOptions } from 'graphql-redis-subscriptions/dist/redis-pubsub';`