### PR TITLE
Fix CI by using pinned version of redis-cluster

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         ports:
           - 6379:6379
       redis-cluster:
-        image: grokzen/redis-cluster:latest
+        image: grokzen/redis-cluster:7.0.10
         ports:
           - 7006:7000
           - 7001:7001


### PR DESCRIPTION
The grokzen/redis-cluster:latest image is not latest: https://github.com/Grokzen/docker-redis-cluster/issues/162.

This PR pins the version to 7.0.10, which is currently the latest.