### PR TITLE
build: target es2020 instead of es5

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,


### PR DESCRIPTION
In order to make debugging easier, build the library into es2020 instead of es5.

Transpiling async..await into es5 makes using debugger harder than it needs to be.