### PR TITLE
add option to skip punsubscribe call

### DIFF
--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -117,6 +117,26 @@ describe('RedisPubSub', () => {
     });
   });
 
+  it('skips punsubscribe when skipPunsubscribe is set to true', done => {
+    const pubSub = new RedisPubSub({...mockOptions, skipPunsubscribe: true});
+    pubSub.subscribe('Posts', () => null).then(subId => {
+      pubSub.unsubscribe(subId);
+
+      try {
+
+        expect(unsubscribeSpy.callCount).to.equals(1);
+        expect(unsubscribeSpy.lastCall.args).to.have.members(['Posts']);
+
+        expect(punsubscribeSpy.callCount).to.equals(0);
+
+        done();
+
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+
   it('cleans up correctly the memory when unsubscribing', done => {
     const pubSub = new RedisPubSub(mockOptions);
     Promise.all([


### PR DESCRIPTION
Closes #654 

Prevents errors when running with a Redis or Valkey server that doesn't support `PUNSUBSCRIBE`, as is the case with ElastiCache Serverless.